### PR TITLE
Add package `EG.ReferentialIntegrity` version 1.0.0

### DIFF
--- a/packages/e/eg.referentialintegrity/1.0.0/README.md
+++ b/packages/e/eg.referentialintegrity/1.0.0/README.md
@@ -1,0 +1,53 @@
+# EG.ReferentialIntegrity
+
+Generates a DAX query string that, when evaluated, returns a table listing referential integrity violations across all model relationships — identifying fact-side values with no matching entry in the related dimension.
+
+Full explanation of the logic: [Referential Integrity Monitor for Power BI Reports](https://www.linkedin.com/pulse/referential-integrity-monitor-power-bi-reports-erick-oliveira-gghuf/)
+
+## Functions
+
+### `EG.ReferentialIntegrity.Monitor`
+
+Inspects all relationships in the model via `INFO.VIEW.RELATIONSHIPS()` and returns a single-row table whose only column contains a ready-to-evaluate DAX expression. Evaluating that expression produces a table with one row per relationship, showing the invalid values and their count.
+
+**Parameters**
+
+None.
+
+**Returns** `table` — one row with column `Referential_Integrity` containing the generated DAX query string.
+
+**Usage**
+
+**Step 1** — Run the function in DAX Studio to get the generated DAX code:
+
+```dax
+EVALUATE
+EG.ReferentialIntegrity.Monitor ()
+```
+
+**Step 2** — Copy the value from the `Referential_Integrity` column.
+
+**Step 3** — In Power BI Desktop, create a new **Calculated Table** and paste the copied expression as its definition. This table will automatically refresh and monitor all model relationships, showing which values in fact tables have no matching entry in the related dimension.
+
+Once the calculated table exists, you can build a dedicated report page on top of it — for developers or end users — to continuously track referential integrity issues across the entire model.
+
+The calculated table returns the following columns per relationship:
+
+| Column | Description |
+|---|---|
+| `ID` | Relationship ID |
+| `FromTable` / `FromColumn` | Fact-side table and column |
+| `ToTable` / `ToColumn` | Dimension-side table and column |
+| `FromCardinality` / `ToCardinality` | Relationship cardinality |
+| `IsActive` | Whether the relationship is active |
+| `Direction` | Cross-filtering direction |
+| `FromTo` | Relationship description |
+| `Invalid Values` | Pipe-delimited list of unmatched values |
+| `Invalid Rows` | Count of unmatched values |
+
+## Notes
+
+- Uses `INFO.VIEW.RELATIONSHIPS()` to dynamically discover all model relationships at query time
+- Skips Many-to-Many relationships with bidirectional cross-filtering
+- For active One-to-Many relationships: detects fact-side values with no dimension match via `CALCULATETABLE` + `ISBLANK`
+- For inactive, One-to-One, or Many-to-Many relationships: detects mismatches via `EXCEPT`

--- a/packages/e/eg.referentialintegrity/1.0.0/lib/functions.tmdl
+++ b/packages/e/eg.referentialintegrity/1.0.0/lib/functions.tmdl
@@ -1,0 +1,86 @@
+function 'EG.ReferentialIntegrity.Monitor' =
+	( ) =>
+	VAR _relationships =
+	    INFO.VIEW.RELATIONSHIPS ()
+	VAR _resultRelationships =
+	    SELECTCOLUMNS (
+	        FILTER (
+	            _relationships,
+	            NOT
+	            ( [FromCardinality], [ToCardinality], [CrossFilteringBehavior] )
+	                IN { ( "Many", "Many", "BothDirections" ) }
+	        ),
+	        "ID", [ID],
+	        "FromTable", [FromTable],
+	        "FromColumn", [FromColumn],
+	        "FromCardinality", [FromCardinality],
+	        "From",
+	            "'" & [FromTable] & "'" & "[" & [FromColumn] & "]",
+	        "ToTable", [ToTable],
+	        "ToColumn", [ToColumn],
+	        "ToCardinality", [ToCardinality],
+	        "To",
+	            "'" & [ToTable] & "'" & "[" & [ToColumn] & "]",
+	        "IsActive", [IsActive],
+	        "Direction", [CrossFilteringBehavior],
+	        "FromTo", [Relationship]
+	    )
+	VAR _tableConstructor =
+	    "SELECTCOLUMNS ( {("
+	        & CONCATENATEX (
+	            _resultRelationships,
+	            [ID] & ", """ & [FromTable] & """, """ & [FromColumn] & """, """ & [FromCardinality] & """, """ & [From]
+	            & """, """ & [ToTable] & """, """ & [ToColumn] & """, """ & [ToCardinality] & """, """ & [To]
+	            & """, " & [IsActive] & "(), """ & [Direction] & """, """ & [FromTo] & """",
+	            "), ("
+	        ) & ")},
+				""ID"", [Value1],
+				""FromTable"", [Value2],
+				""FromColumn"", [Value3],
+				""FromCardinality"", [Value4],
+				""From"", [Value5],
+				""ToTable"", [Value6],
+				""ToColumn"", [Value7],
+				""ToCardinality"", [Value8],
+				""To"", [Value9],
+				""IsActive"", [Value10],
+				""Direction"", [Value11],
+				""FromTo"", [Value12]
+			)"
+	VAR _Delimiter = "|"
+	VAR _DAX_Evaluate =
+	    "SWITCH ( [ID],"
+	        & CONCATENATEX (
+	            _resultRelationships,
+	            [ID] & ", "
+	                & IF (
+	                    [IsActive] = FALSE () || [FromCardinality] & [ToCardinality] = "ManyMany" || [FromCardinality] & [ToCardinality] = "OneOne",
+	                    "CONCATENATEX ( EXCEPT ( DISTINCT ( " & [From] & " ), DISTINCT ( " & [To] & " ) ), " & [From] & ", """ & _Delimiter & """ ) ",
+	                    "CONCATENATEX ( CALCULATETABLE ( DISTINCT ( " & [From] & " ), ISBLANK ( " & [To] & " ) ), " & [From] & ", """ & _Delimiter & """ ) "
+	                ),
+	            ", "
+	        ) & " )"
+	VAR _finalQuery =
+	    " = GENERATE ( " & _tableConstructor & ", VAR _InvalidValues = " & _DAX_Evaluate &
+	    "VAR _Length =
+		PATHLENGTH ( _InvalidValues ) + 0
+		VAR _InvalidValuesList =
+			SELECTCOLUMNS (
+				GENERATESERIES ( 1, _Length ),
+				""Item"", PATHITEM ( _InvalidValues, [Value], TEXT )
+			)
+		VAR _Count = COUNTROWS ( _InvalidValuesList )
+		RETURN
+			ROW (
+				""Invalid Values"", _InvalidValues,
+				""Invalid Rows"", _Count
+			)
+	)"
+	RETURN
+	    SELECTCOLUMNS (
+	        { _finalQuery },
+	        "Referential_Integrity", [Value]
+	    )
+
+	annotation DAXLIB_PackageId = EG.ReferentialIntegrity
+	annotation DAXLIB_PackageVersion = 1.0.0

--- a/packages/e/eg.referentialintegrity/1.0.0/lib/functions.tmdl
+++ b/packages/e/eg.referentialintegrity/1.0.0/lib/functions.tmdl
@@ -1,86 +1,86 @@
 function 'EG.ReferentialIntegrity.Monitor' =
-	( ) =>
-	VAR _relationships =
-	    INFO.VIEW.RELATIONSHIPS ()
-	VAR _resultRelationships =
-	    SELECTCOLUMNS (
-	        FILTER (
-	            _relationships,
-	            NOT
-	            ( [FromCardinality], [ToCardinality], [CrossFilteringBehavior] )
-	                IN { ( "Many", "Many", "BothDirections" ) }
-	        ),
-	        "ID", [ID],
-	        "FromTable", [FromTable],
-	        "FromColumn", [FromColumn],
-	        "FromCardinality", [FromCardinality],
-	        "From",
-	            "'" & [FromTable] & "'" & "[" & [FromColumn] & "]",
-	        "ToTable", [ToTable],
-	        "ToColumn", [ToColumn],
-	        "ToCardinality", [ToCardinality],
-	        "To",
-	            "'" & [ToTable] & "'" & "[" & [ToColumn] & "]",
-	        "IsActive", [IsActive],
-	        "Direction", [CrossFilteringBehavior],
-	        "FromTo", [Relationship]
-	    )
-	VAR _tableConstructor =
-	    "SELECTCOLUMNS ( {("
-	        & CONCATENATEX (
-	            _resultRelationships,
-	            [ID] & ", """ & [FromTable] & """, """ & [FromColumn] & """, """ & [FromCardinality] & """, """ & [From]
-	            & """, """ & [ToTable] & """, """ & [ToColumn] & """, """ & [ToCardinality] & """, """ & [To]
-	            & """, " & [IsActive] & "(), """ & [Direction] & """, """ & [FromTo] & """",
-	            "), ("
-	        ) & ")},
-				""ID"", [Value1],
-				""FromTable"", [Value2],
-				""FromColumn"", [Value3],
-				""FromCardinality"", [Value4],
-				""From"", [Value5],
-				""ToTable"", [Value6],
-				""ToColumn"", [Value7],
-				""ToCardinality"", [Value8],
-				""To"", [Value9],
-				""IsActive"", [Value10],
-				""Direction"", [Value11],
-				""FromTo"", [Value12]
-			)"
-	VAR _Delimiter = "|"
-	VAR _DAX_Evaluate =
-	    "SWITCH ( [ID],"
-	        & CONCATENATEX (
-	            _resultRelationships,
-	            [ID] & ", "
-	                & IF (
-	                    [IsActive] = FALSE () || [FromCardinality] & [ToCardinality] = "ManyMany" || [FromCardinality] & [ToCardinality] = "OneOne",
-	                    "CONCATENATEX ( EXCEPT ( DISTINCT ( " & [From] & " ), DISTINCT ( " & [To] & " ) ), " & [From] & ", """ & _Delimiter & """ ) ",
-	                    "CONCATENATEX ( CALCULATETABLE ( DISTINCT ( " & [From] & " ), ISBLANK ( " & [To] & " ) ), " & [From] & ", """ & _Delimiter & """ ) "
-	                ),
-	            ", "
-	        ) & " )"
-	VAR _finalQuery =
-	    " = GENERATE ( " & _tableConstructor & ", VAR _InvalidValues = " & _DAX_Evaluate &
-	    "VAR _Length =
-		PATHLENGTH ( _InvalidValues ) + 0
-		VAR _InvalidValuesList =
-			SELECTCOLUMNS (
-				GENERATESERIES ( 1, _Length ),
-				""Item"", PATHITEM ( _InvalidValues, [Value], TEXT )
-			)
-		VAR _Count = COUNTROWS ( _InvalidValuesList )
-		RETURN
-			ROW (
-				""Invalid Values"", _InvalidValues,
-				""Invalid Rows"", _Count
-			)
-	)"
-	RETURN
-	    SELECTCOLUMNS (
-	        { _finalQuery },
-	        "Referential_Integrity", [Value]
-	    )
+	    ( ) =>
+	    VAR _relationships =
+	        INFO.VIEW.RELATIONSHIPS ()
+	    VAR _resultRelationships =
+	        SELECTCOLUMNS (
+	            FILTER (
+	                _relationships,
+	                NOT
+	                ( [FromCardinality], [ToCardinality], [CrossFilteringBehavior] )
+	                    IN { ( "Many", "Many", "BothDirections" ) }
+	            ),
+	            "ID", [ID],
+	            "FromTable", [FromTable],
+	            "FromColumn", [FromColumn],
+	            "FromCardinality", [FromCardinality],
+	            "From",
+	                "'" & [FromTable] & "'" & "[" & [FromColumn] & "]",
+	            "ToTable", [ToTable],
+	            "ToColumn", [ToColumn],
+	            "ToCardinality", [ToCardinality],
+	            "To",
+	                "'" & [ToTable] & "'" & "[" & [ToColumn] & "]",
+	            "IsActive", [IsActive],
+	            "Direction", [CrossFilteringBehavior],
+	            "FromTo", [Relationship]
+	        )
+	    VAR _tableConstructor =
+	        "SELECTCOLUMNS ( {("
+	            & CONCATENATEX (
+	                _resultRelationships,
+	                [ID] & ", """ & [FromTable] & """, """ & [FromColumn] & """, """ & [FromCardinality] & """, """ & [From]
+	                & """, """ & [ToTable] & """, """ & [ToColumn] & """, """ & [ToCardinality] & """, """ & [To]
+	                & """, " & [IsActive] & "(), """ & [Direction] & """, """ & [FromTo] & """",
+	                "), ("
+	            ) & ")},
+	    			""ID"", [Value1],
+	    			""FromTable"", [Value2],
+	    			""FromColumn"", [Value3],
+	    			""FromCardinality"", [Value4],
+	    			""From"", [Value5],
+	    			""ToTable"", [Value6],
+	    			""ToColumn"", [Value7],
+	    			""ToCardinality"", [Value8],
+	    			""To"", [Value9],
+	    			""IsActive"", [Value10],
+	    			""Direction"", [Value11],
+	    			""FromTo"", [Value12]
+	    		)"
+	    VAR _Delimiter = "|"
+	    VAR _DAX_Evaluate =
+	        "SWITCH ( [ID],"
+	            & CONCATENATEX (
+	                _resultRelationships,
+	                [ID] & ", "
+	                    & IF (
+	                        [IsActive] = FALSE () || [FromCardinality] & [ToCardinality] = "ManyMany" || [FromCardinality] & [ToCardinality] = "OneOne",
+	                        "CONCATENATEX ( EXCEPT ( DISTINCT ( " & [From] & " ), DISTINCT ( " & [To] & " ) ), " & [From] & ", """ & _Delimiter & """ ) ",
+	                        "CONCATENATEX ( CALCULATETABLE ( DISTINCT ( " & [From] & " ), ISBLANK ( " & [To] & " ) ), " & [From] & ", """ & _Delimiter & """ ) "
+	                    ),
+	                ", "
+	            ) & " )"
+	    VAR _finalQuery =
+	        " = GENERATE ( " & _tableConstructor & ", VAR _InvalidValues = " & _DAX_Evaluate &
+	        "VAR _Length =
+	    	PATHLENGTH ( _InvalidValues ) + 0
+	    	VAR _InvalidValuesList =
+	    		SELECTCOLUMNS (
+	    			GENERATESERIES ( 1, _Length ),
+	    			""Item"", PATHITEM ( _InvalidValues, [Value], TEXT )
+	    		)
+	    	VAR _Count = COUNTROWS ( _InvalidValuesList )
+	    	RETURN
+	    		ROW (
+	    			""Invalid Values"", _InvalidValues,
+	    			""Invalid Rows"", _Count
+	    		)
+	    )"
+	    RETURN
+	        SELECTCOLUMNS (
+	            { _finalQuery },
+	            "Referential_Integrity", [Value]
+	        )
 
 	annotation DAXLIB_PackageId = EG.ReferentialIntegrity
 	annotation DAXLIB_PackageVersion = 1.0.0

--- a/packages/e/eg.referentialintegrity/1.0.0/manifest.daxlib
+++ b/packages/e/eg.referentialintegrity/1.0.0/manifest.daxlib
@@ -6,5 +6,6 @@
   "description": "Generates a DAX query string that, when evaluated, returns a table listing referential integrity violations across all model relationships.",
   "tags": "DAX,Referential Integrity,Data Quality,Relationships,INFO.VIEW,Model",
   "releaseNotes": "Initial release.",
-  "projectUrl": "https://www.linkedin.com/pulse/referential-integrity-monitor-power-bi-reports-erick-oliveira-gghuf/"
+  "projectUrl": "https://www.linkedin.com/pulse/referential-integrity-monitor-power-bi-reports-erick-oliveira-gghuf/",
+  "readme": "/README.md"
 }

--- a/packages/e/eg.referentialintegrity/1.0.0/manifest.daxlib
+++ b/packages/e/eg.referentialintegrity/1.0.0/manifest.daxlib
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/daxlib/daxlib/refs/heads/main/schemas/manifest/1.0.0/manifest.1.0.0.schema.json",
+  "id": "EG.ReferentialIntegrity",
+  "version": "1.0.0",
+  "authors": "ErickOliverG",
+  "description": "Generates a DAX query string that, when evaluated, returns a table listing referential integrity violations across all model relationships.",
+  "tags": "DAX,Referential Integrity,Data Quality,Relationships,INFO.VIEW,Model",
+  "releaseNotes": "Initial release.",
+  "projectUrl": "https://www.linkedin.com/pulse/referential-integrity-monitor-power-bi-reports-erick-oliveira-gghuf/"
+}


### PR DESCRIPTION
Generates a DAX query string that, when evaluated, returns a table listing referential integrity violations across all model relationships, identifying fact-side values with no matching entry in the related dimension.