### PR TITLE
Add package `DataZoe.SVG` version 0.1.0

### DIFF
--- a/packages/d/datazoe.svg/0.1.0/README.md
+++ b/packages/d/datazoe.svg/0.1.0/README.md
@@ -1,0 +1,46 @@
+# DataZoe.SVG
+
+SVG-based visuals authored as DAX user-defined functions. Drop these into any Power BI semantic model and use the returned `data:image/svg+xml;utf8,...` string in a table/matrix column formatted as **Image URL**, or in a card visual.
+
+## Functions
+
+### `DataZoe.SVG.TrendSVG`
+
+A compact inline trend / sparkline chart. Grain-agnostic — works with any date/period column (day, month, quarter, year).
+
+**Signature**
+
+```dax
+DataZoe.SVG.TrendSVG(
+    valueExpression,            // measure or scalar expression to plot
+    periodDateColumn,           // date/period column (e.g. 'Date'[Month])
+    numberOfPeriods,            // most-recent N periods to include (e.g. 12)
+    axisLabelCharactersToShow,  // characters to keep from the formatted period label (e.g. 3 → "JAN")
+    dateFormatString,           // FORMAT string for axis labels (e.g. "MMM", "yyyy")
+    valueFormatString,          // FORMAT string for value data labels (e.g. "#,0", "$#,0", "0.0%")
+    lineColor,                  // hex color for the line/markers (e.g. "#0078D4")
+    hover                       // TRUE to include shading and value labels, FALSE for minimal
+)
+```
+
+**Example**
+
+```dax
+Sales Trend =
+DataZoe.SVG.TrendSVG(
+    [Total Sales],
+    'Date'[Month],
+    12,
+    3,
+    "MMM",
+    "$#,0",
+    "#0078D4",
+    TRUE
+)
+```
+
+Add the measure to a table/matrix column and set the column's **Data category** to *Image URL*.
+
+## License
+
+MIT

--- a/packages/d/datazoe.svg/0.1.0/lib/functions.tmdl
+++ b/packages/d/datazoe.svg/0.1.0/lib/functions.tmdl
@@ -1,0 +1,190 @@
+/// Renders a compact inline SVG trend/sparkline chart as a data URI.
+/// Returns a `data:image/svg+xml;utf8,...` string that can be displayed in a
+/// Power BI table/matrix column formatted as Image URL, or in a card visual.
+/// The chart shows the N most recent periods (grain-agnostic: day / month / year / etc.),
+/// with a polyline, dot markers, vertical guides, and period axis labels.
+/// When `hover` is TRUE, additional shading (green rising / red falling) and bold
+/// value labels are included.
+/// @param valueExpression The measure or scalar expression to plot (evaluated per period).
+/// @param periodDateColumn The date/period column used for the X axis (e.g. 'Date'[Month]).
+/// @param numberOfPeriods How many of the most recent periods to include (e.g. 12).
+/// @param axisLabelCharactersToShow Number of characters to keep from the formatted period label (e.g. 3 for "JAN").
+/// @param dateFormatString FORMAT string for the period axis labels (e.g. "MMM", "yyyy").
+/// @param valueFormatString FORMAT string for the value data labels (e.g. "#,0", "$#,0", "0.0%").
+/// @param lineColor Hex color used for the line and markers (e.g. "#0078D4").
+/// @param hover TRUE to include hover-only shading and value labels, FALSE for a minimal chart.
+/// @returns A `data:image/svg+xml;utf8,...` string, or BLANK when there is insufficient data.
+FUNCTION 'DataZoe.SVG.TrendSVG' =
+    (
+        valueExpression: ANYREF EXPR,
+        periodDateColumn: ANYREF EXPR,
+        numberOfPeriods: INT64,
+        axisLabelCharactersToShow: INT64,
+        dateFormatString: STRING,
+        valueFormatString: STRING,
+        lineColor: STRING,
+        hover: BOOLEAN
+    ) =>
+    VAR _LastPeriod = MAX ( periodDateColumn )
+    VAR _BasePeriods =
+        TOPN (
+            numberOfPeriods,
+            FILTER ( ALL ( periodDateColumn ), periodDateColumn <= _LastPeriod ),
+            periodDateColumn,
+            DESC
+        )
+    VAR _Data =
+        ADDCOLUMNS (
+            _BasePeriods,
+            "Value",
+                VAR _v = CALCULATE ( valueExpression )
+                RETURN IF ( ISBLANK ( _v ), 0, _v )
+        )
+    VAR _DataIndexed =
+        ADDCOLUMNS (
+            _Data,
+            "Idx",
+                RANKX ( _Data, periodDateColumn, periodDateColumn, ASC, DENSE ),
+            "PeriodLabel",
+                UPPER ( LEFT ( FORMAT ( periodDateColumn, dateFormatString ), axisLabelCharactersToShow ) )
+        )
+    VAR _Count = COUNTROWS ( _DataIndexed )
+    VAR _MaxVal = MAXX ( _DataIndexed, [Value] )
+    VAR _PerPointX = 32
+    VAR _PadX = 18
+    VAR _Width = 2 * _PadX + MAX ( 1, _Count - 1 ) * _PerPointX
+    VAR _Height = 86
+    VAR _PadTop = 10
+    VAR _LabelBandH = 26
+    VAR _ChartBottom = _Height - _LabelBandH
+    VAR _GoodColor = "#107C10"
+    VAR _BadColor = "#A80000"
+    VAR _LineColor = lineColor
+    VAR _XStep =
+        IF ( _Count > 1, DIVIDE ( _Width - 2 * _PadX, _Count - 1 ), 0 )
+    VAR _HasData =
+        _Count >= 2 && NOT ISBLANK ( _MaxVal )
+    VAR _Points =
+        CONCATENATEX (
+            _DataIndexed,
+            VAR _Idx = [Idx]
+            VAR _Val = [Value]
+            VAR _Norm = IF ( _MaxVal = 0, 0, DIVIDE ( _Val, _MaxVal ) )
+            VAR _X = _PadX + ( _Idx - 1 ) * _XStep
+            VAR _Y = _ChartBottom - _Norm * ( _ChartBottom - _PadTop )
+            RETURN FORMAT ( _X, "0.0" ) & "," & FORMAT ( _Y, "0.0" ),
+            " ",
+            [Idx], ASC
+        )
+    VAR _Markers =
+        CONCATENATEX (
+            _DataIndexed,
+            VAR _mIdx = [Idx]
+            VAR _mVal = [Value]
+            VAR _mNorm = IF ( _MaxVal = 0, 0, DIVIDE ( _mVal, _MaxVal ) )
+            VAR _mX = _PadX + ( _mIdx - 1 ) * _XStep
+            VAR _mY = _ChartBottom - _mNorm * ( _ChartBottom - _PadTop )
+            RETURN
+                "<circle cx='" & FORMAT ( _mX, "0.0" )
+                    & "' cy='" & FORMAT ( _mY, "0.0" )
+                    & "' r='2.2' fill='" & _LineColor & "' />",
+            "",
+            [Idx], ASC
+        )
+    VAR _GuideBottom = _ChartBottom
+    VAR _Guides =
+        CONCATENATEX (
+            _DataIndexed,
+            VAR _gIdx = [Idx]
+            VAR _gVal = [Value]
+            VAR _gNorm = IF ( _MaxVal = 0, 0, DIVIDE ( _gVal, _MaxVal ) )
+            VAR _gX = _PadX + ( _gIdx - 1 ) * _XStep
+            VAR _gY = _ChartBottom - _gNorm * ( _ChartBottom - _PadTop )
+            RETURN
+                "<line x1='" & FORMAT ( _gX, "0.0" )
+                    & "' y1='" & FORMAT ( _gY, "0.0" )
+                    & "' x2='" & FORMAT ( _gX, "0.0" )
+                    & "' y2='" & FORMAT ( _GuideBottom, "0.0" )
+                    & "' stroke='#CCCCCC' stroke-width='0.75' />",
+            "",
+            [Idx], ASC
+        )
+    VAR _LabelY = _Height - 16
+    VAR _Labels =
+        CONCATENATEX (
+            _DataIndexed,
+            VAR _lIdx = [Idx]
+            VAR _lX = _PadX + ( _lIdx - 1 ) * _XStep
+            RETURN
+                "<text x='" & FORMAT ( _lX, "0.0" )
+                    & "' y='" & FORMAT ( _LabelY, "0.0" )
+                    & "' text-anchor='middle' font-family='DIN, &quot;DIN Alternate&quot;, &quot;DIN Next&quot;, &quot;Segoe UI&quot;, Tahoma, Arial, sans-serif' font-size='8' fill='#666'>"
+                    & [PeriodLabel]
+                    & "</text>",
+            "",
+            [Idx], ASC
+        )
+    VAR _Shades =
+        CONCATENATEX (
+            FILTER ( _DataIndexed, [Idx] < _Count ),
+            VAR _sIdx = [Idx]
+            VAR _sVal = [Value]
+            VAR _sNext = MAXX ( FILTER ( _DataIndexed, [Idx] = _sIdx + 1 ), [Value] )
+            VAR _sNorm1 = IF ( _MaxVal = 0, 0, DIVIDE ( _sVal, _MaxVal ) )
+            VAR _sNorm2 = IF ( _MaxVal = 0, 0, DIVIDE ( _sNext, _MaxVal ) )
+            VAR _sX1 = _PadX + ( _sIdx - 1 ) * _XStep
+            VAR _sX2 = _PadX + _sIdx * _XStep
+            VAR _sY1 = _ChartBottom - _sNorm1 * ( _ChartBottom - _PadTop )
+            VAR _sY2 = _ChartBottom - _sNorm2 * ( _ChartBottom - _PadTop )
+            VAR _sColor = IF ( _sNext >= _sVal, _GoodColor, _BadColor )
+            RETURN
+                "<polygon points='"
+                    & FORMAT ( _sX1, "0.0" ) & "," & FORMAT ( _sY1, "0.0" ) & " "
+                    & FORMAT ( _sX2, "0.0" ) & "," & FORMAT ( _sY2, "0.0" ) & " "
+                    & FORMAT ( _sX2, "0.0" ) & "," & FORMAT ( _ChartBottom, "0.0" ) & " "
+                    & FORMAT ( _sX1, "0.0" ) & "," & FORMAT ( _ChartBottom, "0.0" )
+                    & "' fill='" & _sColor & "' fill-opacity='0.05' stroke='none' />",
+            "",
+            [Idx], ASC
+        )
+    VAR _ValueLabelY = _Height - 6
+    VAR _DataLabels =
+        CONCATENATEX (
+            _DataIndexed,
+            VAR _dIdx = [Idx]
+            VAR _dVal = [Value]
+            VAR _dX = _PadX + ( _dIdx - 1 ) * _XStep
+            RETURN
+                "<text x='" & FORMAT ( _dX, "0.0" )
+                    & "' y='" & FORMAT ( _ValueLabelY, "0.0" )
+                    & "' text-anchor='middle' font-family='DIN, &quot;DIN Alternate&quot;, &quot;DIN Next&quot;, &quot;Segoe UI&quot;, Tahoma, Arial, sans-serif' font-size='7' font-weight='bold' fill='#333'>"
+                    & FORMAT ( _dVal, valueFormatString )
+                    & "</text>",
+            "",
+            [Idx], ASC
+        )
+    VAR _HoverExtras = IF ( hover, _Shades, "" )
+    VAR _HoverLabels = IF ( hover, _DataLabels, "" )
+    VAR _SVGContent =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 "
+            & FORMAT ( _Width, "0" ) & " " & FORMAT ( _Height, "0" )
+            & "' preserveAspectRatio='xMidYMid meet'>"
+            & _HoverExtras
+            & _Guides
+            & "<polyline fill='none' stroke='" & _LineColor
+            & "' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' points='"
+            & _Points
+            & "' />"
+            & _Markers
+            & _Labels
+            & _HoverLabels
+            & "</svg>"
+    RETURN
+        IF (
+            _HasData,
+            "data:image/svg+xml;utf8," & _SVGContent,
+            BLANK ()
+        )
+
+    annotation DAXLIB_PackageId = DataZoe.SVG
+    annotation DAXLIB_PackageVersion = 0.1.0

--- a/packages/d/datazoe.svg/0.1.0/lib/functions.tmdl
+++ b/packages/d/datazoe.svg/0.1.0/lib/functions.tmdl
@@ -15,176 +15,176 @@
 /// @param hover TRUE to include hover-only shading and value labels, FALSE for a minimal chart.
 /// @returns A `data:image/svg+xml;utf8,...` string, or BLANK when there is insufficient data.
 FUNCTION 'DataZoe.SVG.TrendSVG' =
-    (
-        valueExpression: ANYREF EXPR,
-        periodDateColumn: ANYREF EXPR,
-        numberOfPeriods: INT64,
-        axisLabelCharactersToShow: INT64,
-        dateFormatString: STRING,
-        valueFormatString: STRING,
-        lineColor: STRING,
-        hover: BOOLEAN
-    ) =>
-    VAR _LastPeriod = MAX ( periodDateColumn )
-    VAR _BasePeriods =
-        TOPN (
-            numberOfPeriods,
-            FILTER ( ALL ( periodDateColumn ), periodDateColumn <= _LastPeriod ),
-            periodDateColumn,
-            DESC
-        )
-    VAR _Data =
-        ADDCOLUMNS (
-            _BasePeriods,
-            "Value",
-                VAR _v = CALCULATE ( valueExpression )
-                RETURN IF ( ISBLANK ( _v ), 0, _v )
-        )
-    VAR _DataIndexed =
-        ADDCOLUMNS (
-            _Data,
-            "Idx",
-                RANKX ( _Data, periodDateColumn, periodDateColumn, ASC, DENSE ),
-            "PeriodLabel",
-                UPPER ( LEFT ( FORMAT ( periodDateColumn, dateFormatString ), axisLabelCharactersToShow ) )
-        )
-    VAR _Count = COUNTROWS ( _DataIndexed )
-    VAR _MaxVal = MAXX ( _DataIndexed, [Value] )
-    VAR _PerPointX = 32
-    VAR _PadX = 18
-    VAR _Width = 2 * _PadX + MAX ( 1, _Count - 1 ) * _PerPointX
-    VAR _Height = 86
-    VAR _PadTop = 10
-    VAR _LabelBandH = 26
-    VAR _ChartBottom = _Height - _LabelBandH
-    VAR _GoodColor = "#107C10"
-    VAR _BadColor = "#A80000"
-    VAR _LineColor = lineColor
-    VAR _XStep =
-        IF ( _Count > 1, DIVIDE ( _Width - 2 * _PadX, _Count - 1 ), 0 )
-    VAR _HasData =
-        _Count >= 2 && NOT ISBLANK ( _MaxVal )
-    VAR _Points =
-        CONCATENATEX (
-            _DataIndexed,
-            VAR _Idx = [Idx]
-            VAR _Val = [Value]
-            VAR _Norm = IF ( _MaxVal = 0, 0, DIVIDE ( _Val, _MaxVal ) )
-            VAR _X = _PadX + ( _Idx - 1 ) * _XStep
-            VAR _Y = _ChartBottom - _Norm * ( _ChartBottom - _PadTop )
-            RETURN FORMAT ( _X, "0.0" ) & "," & FORMAT ( _Y, "0.0" ),
-            " ",
-            [Idx], ASC
-        )
-    VAR _Markers =
-        CONCATENATEX (
-            _DataIndexed,
-            VAR _mIdx = [Idx]
-            VAR _mVal = [Value]
-            VAR _mNorm = IF ( _MaxVal = 0, 0, DIVIDE ( _mVal, _MaxVal ) )
-            VAR _mX = _PadX + ( _mIdx - 1 ) * _XStep
-            VAR _mY = _ChartBottom - _mNorm * ( _ChartBottom - _PadTop )
-            RETURN
-                "<circle cx='" & FORMAT ( _mX, "0.0" )
-                    & "' cy='" & FORMAT ( _mY, "0.0" )
-                    & "' r='2.2' fill='" & _LineColor & "' />",
-            "",
-            [Idx], ASC
-        )
-    VAR _GuideBottom = _ChartBottom
-    VAR _Guides =
-        CONCATENATEX (
-            _DataIndexed,
-            VAR _gIdx = [Idx]
-            VAR _gVal = [Value]
-            VAR _gNorm = IF ( _MaxVal = 0, 0, DIVIDE ( _gVal, _MaxVal ) )
-            VAR _gX = _PadX + ( _gIdx - 1 ) * _XStep
-            VAR _gY = _ChartBottom - _gNorm * ( _ChartBottom - _PadTop )
-            RETURN
-                "<line x1='" & FORMAT ( _gX, "0.0" )
-                    & "' y1='" & FORMAT ( _gY, "0.0" )
-                    & "' x2='" & FORMAT ( _gX, "0.0" )
-                    & "' y2='" & FORMAT ( _GuideBottom, "0.0" )
-                    & "' stroke='#CCCCCC' stroke-width='0.75' />",
-            "",
-            [Idx], ASC
-        )
-    VAR _LabelY = _Height - 16
-    VAR _Labels =
-        CONCATENATEX (
-            _DataIndexed,
-            VAR _lIdx = [Idx]
-            VAR _lX = _PadX + ( _lIdx - 1 ) * _XStep
-            RETURN
-                "<text x='" & FORMAT ( _lX, "0.0" )
-                    & "' y='" & FORMAT ( _LabelY, "0.0" )
-                    & "' text-anchor='middle' font-family='DIN, &quot;DIN Alternate&quot;, &quot;DIN Next&quot;, &quot;Segoe UI&quot;, Tahoma, Arial, sans-serif' font-size='8' fill='#666'>"
-                    & [PeriodLabel]
-                    & "</text>",
-            "",
-            [Idx], ASC
-        )
-    VAR _Shades =
-        CONCATENATEX (
-            FILTER ( _DataIndexed, [Idx] < _Count ),
-            VAR _sIdx = [Idx]
-            VAR _sVal = [Value]
-            VAR _sNext = MAXX ( FILTER ( _DataIndexed, [Idx] = _sIdx + 1 ), [Value] )
-            VAR _sNorm1 = IF ( _MaxVal = 0, 0, DIVIDE ( _sVal, _MaxVal ) )
-            VAR _sNorm2 = IF ( _MaxVal = 0, 0, DIVIDE ( _sNext, _MaxVal ) )
-            VAR _sX1 = _PadX + ( _sIdx - 1 ) * _XStep
-            VAR _sX2 = _PadX + _sIdx * _XStep
-            VAR _sY1 = _ChartBottom - _sNorm1 * ( _ChartBottom - _PadTop )
-            VAR _sY2 = _ChartBottom - _sNorm2 * ( _ChartBottom - _PadTop )
-            VAR _sColor = IF ( _sNext >= _sVal, _GoodColor, _BadColor )
-            RETURN
-                "<polygon points='"
-                    & FORMAT ( _sX1, "0.0" ) & "," & FORMAT ( _sY1, "0.0" ) & " "
-                    & FORMAT ( _sX2, "0.0" ) & "," & FORMAT ( _sY2, "0.0" ) & " "
-                    & FORMAT ( _sX2, "0.0" ) & "," & FORMAT ( _ChartBottom, "0.0" ) & " "
-                    & FORMAT ( _sX1, "0.0" ) & "," & FORMAT ( _ChartBottom, "0.0" )
-                    & "' fill='" & _sColor & "' fill-opacity='0.05' stroke='none' />",
-            "",
-            [Idx], ASC
-        )
-    VAR _ValueLabelY = _Height - 6
-    VAR _DataLabels =
-        CONCATENATEX (
-            _DataIndexed,
-            VAR _dIdx = [Idx]
-            VAR _dVal = [Value]
-            VAR _dX = _PadX + ( _dIdx - 1 ) * _XStep
-            RETURN
-                "<text x='" & FORMAT ( _dX, "0.0" )
-                    & "' y='" & FORMAT ( _ValueLabelY, "0.0" )
-                    & "' text-anchor='middle' font-family='DIN, &quot;DIN Alternate&quot;, &quot;DIN Next&quot;, &quot;Segoe UI&quot;, Tahoma, Arial, sans-serif' font-size='7' font-weight='bold' fill='#333'>"
-                    & FORMAT ( _dVal, valueFormatString )
-                    & "</text>",
-            "",
-            [Idx], ASC
-        )
-    VAR _HoverExtras = IF ( hover, _Shades, "" )
-    VAR _HoverLabels = IF ( hover, _DataLabels, "" )
-    VAR _SVGContent =
-        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 "
-            & FORMAT ( _Width, "0" ) & " " & FORMAT ( _Height, "0" )
-            & "' preserveAspectRatio='xMidYMid meet'>"
-            & _HoverExtras
-            & _Guides
-            & "<polyline fill='none' stroke='" & _LineColor
-            & "' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' points='"
-            & _Points
-            & "' />"
-            & _Markers
-            & _Labels
-            & _HoverLabels
-            & "</svg>"
-    RETURN
-        IF (
-            _HasData,
-            "data:image/svg+xml;utf8," & _SVGContent,
-            BLANK ()
-        )
+        (
+            valueExpression: ANYREF EXPR,
+            periodDateColumn: ANYREF EXPR,
+            numberOfPeriods: INT64,
+            axisLabelCharactersToShow: INT64,
+            dateFormatString: STRING,
+            valueFormatString: STRING,
+            lineColor: STRING,
+            hover: BOOLEAN
+        ) =>
+        VAR _LastPeriod = MAX ( periodDateColumn )
+        VAR _BasePeriods =
+            TOPN (
+                numberOfPeriods,
+                FILTER ( ALL ( periodDateColumn ), periodDateColumn <= _LastPeriod ),
+                periodDateColumn,
+                DESC
+            )
+        VAR _Data =
+            ADDCOLUMNS (
+                _BasePeriods,
+                "Value",
+                    VAR _v = CALCULATE ( valueExpression )
+                    RETURN IF ( ISBLANK ( _v ), 0, _v )
+            )
+        VAR _DataIndexed =
+            ADDCOLUMNS (
+                _Data,
+                "Idx",
+                    RANKX ( _Data, periodDateColumn, periodDateColumn, ASC, DENSE ),
+                "PeriodLabel",
+                    UPPER ( LEFT ( FORMAT ( periodDateColumn, dateFormatString ), axisLabelCharactersToShow ) )
+            )
+        VAR _Count = COUNTROWS ( _DataIndexed )
+        VAR _MaxVal = MAXX ( _DataIndexed, [Value] )
+        VAR _PerPointX = 32
+        VAR _PadX = 18
+        VAR _Width = 2 * _PadX + MAX ( 1, _Count - 1 ) * _PerPointX
+        VAR _Height = 86
+        VAR _PadTop = 10
+        VAR _LabelBandH = 26
+        VAR _ChartBottom = _Height - _LabelBandH
+        VAR _GoodColor = "#107C10"
+        VAR _BadColor = "#A80000"
+        VAR _LineColor = lineColor
+        VAR _XStep =
+            IF ( _Count > 1, DIVIDE ( _Width - 2 * _PadX, _Count - 1 ), 0 )
+        VAR _HasData =
+            _Count >= 2 && NOT ISBLANK ( _MaxVal )
+        VAR _Points =
+            CONCATENATEX (
+                _DataIndexed,
+                VAR _Idx = [Idx]
+                VAR _Val = [Value]
+                VAR _Norm = IF ( _MaxVal = 0, 0, DIVIDE ( _Val, _MaxVal ) )
+                VAR _X = _PadX + ( _Idx - 1 ) * _XStep
+                VAR _Y = _ChartBottom - _Norm * ( _ChartBottom - _PadTop )
+                RETURN FORMAT ( _X, "0.0" ) & "," & FORMAT ( _Y, "0.0" ),
+                " ",
+                [Idx], ASC
+            )
+        VAR _Markers =
+            CONCATENATEX (
+                _DataIndexed,
+                VAR _mIdx = [Idx]
+                VAR _mVal = [Value]
+                VAR _mNorm = IF ( _MaxVal = 0, 0, DIVIDE ( _mVal, _MaxVal ) )
+                VAR _mX = _PadX + ( _mIdx - 1 ) * _XStep
+                VAR _mY = _ChartBottom - _mNorm * ( _ChartBottom - _PadTop )
+                RETURN
+                    "<circle cx='" & FORMAT ( _mX, "0.0" )
+                        & "' cy='" & FORMAT ( _mY, "0.0" )
+                        & "' r='2.2' fill='" & _LineColor & "' />",
+                "",
+                [Idx], ASC
+            )
+        VAR _GuideBottom = _ChartBottom
+        VAR _Guides =
+            CONCATENATEX (
+                _DataIndexed,
+                VAR _gIdx = [Idx]
+                VAR _gVal = [Value]
+                VAR _gNorm = IF ( _MaxVal = 0, 0, DIVIDE ( _gVal, _MaxVal ) )
+                VAR _gX = _PadX + ( _gIdx - 1 ) * _XStep
+                VAR _gY = _ChartBottom - _gNorm * ( _ChartBottom - _PadTop )
+                RETURN
+                    "<line x1='" & FORMAT ( _gX, "0.0" )
+                        & "' y1='" & FORMAT ( _gY, "0.0" )
+                        & "' x2='" & FORMAT ( _gX, "0.0" )
+                        & "' y2='" & FORMAT ( _GuideBottom, "0.0" )
+                        & "' stroke='#CCCCCC' stroke-width='0.75' />",
+                "",
+                [Idx], ASC
+            )
+        VAR _LabelY = _Height - 16
+        VAR _Labels =
+            CONCATENATEX (
+                _DataIndexed,
+                VAR _lIdx = [Idx]
+                VAR _lX = _PadX + ( _lIdx - 1 ) * _XStep
+                RETURN
+                    "<text x='" & FORMAT ( _lX, "0.0" )
+                        & "' y='" & FORMAT ( _LabelY, "0.0" )
+                        & "' text-anchor='middle' font-family='DIN, &quot;DIN Alternate&quot;, &quot;DIN Next&quot;, &quot;Segoe UI&quot;, Tahoma, Arial, sans-serif' font-size='8' fill='#666'>"
+                        & [PeriodLabel]
+                        & "</text>",
+                "",
+                [Idx], ASC
+            )
+        VAR _Shades =
+            CONCATENATEX (
+                FILTER ( _DataIndexed, [Idx] < _Count ),
+                VAR _sIdx = [Idx]
+                VAR _sVal = [Value]
+                VAR _sNext = MAXX ( FILTER ( _DataIndexed, [Idx] = _sIdx + 1 ), [Value] )
+                VAR _sNorm1 = IF ( _MaxVal = 0, 0, DIVIDE ( _sVal, _MaxVal ) )
+                VAR _sNorm2 = IF ( _MaxVal = 0, 0, DIVIDE ( _sNext, _MaxVal ) )
+                VAR _sX1 = _PadX + ( _sIdx - 1 ) * _XStep
+                VAR _sX2 = _PadX + _sIdx * _XStep
+                VAR _sY1 = _ChartBottom - _sNorm1 * ( _ChartBottom - _PadTop )
+                VAR _sY2 = _ChartBottom - _sNorm2 * ( _ChartBottom - _PadTop )
+                VAR _sColor = IF ( _sNext >= _sVal, _GoodColor, _BadColor )
+                RETURN
+                    "<polygon points='"
+                        & FORMAT ( _sX1, "0.0" ) & "," & FORMAT ( _sY1, "0.0" ) & " "
+                        & FORMAT ( _sX2, "0.0" ) & "," & FORMAT ( _sY2, "0.0" ) & " "
+                        & FORMAT ( _sX2, "0.0" ) & "," & FORMAT ( _ChartBottom, "0.0" ) & " "
+                        & FORMAT ( _sX1, "0.0" ) & "," & FORMAT ( _ChartBottom, "0.0" )
+                        & "' fill='" & _sColor & "' fill-opacity='0.05' stroke='none' />",
+                "",
+                [Idx], ASC
+            )
+        VAR _ValueLabelY = _Height - 6
+        VAR _DataLabels =
+            CONCATENATEX (
+                _DataIndexed,
+                VAR _dIdx = [Idx]
+                VAR _dVal = [Value]
+                VAR _dX = _PadX + ( _dIdx - 1 ) * _XStep
+                RETURN
+                    "<text x='" & FORMAT ( _dX, "0.0" )
+                        & "' y='" & FORMAT ( _ValueLabelY, "0.0" )
+                        & "' text-anchor='middle' font-family='DIN, &quot;DIN Alternate&quot;, &quot;DIN Next&quot;, &quot;Segoe UI&quot;, Tahoma, Arial, sans-serif' font-size='7' font-weight='bold' fill='#333'>"
+                        & FORMAT ( _dVal, valueFormatString )
+                        & "</text>",
+                "",
+                [Idx], ASC
+            )
+        VAR _HoverExtras = IF ( hover, _Shades, "" )
+        VAR _HoverLabels = IF ( hover, _DataLabels, "" )
+        VAR _SVGContent =
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 "
+                & FORMAT ( _Width, "0" ) & " " & FORMAT ( _Height, "0" )
+                & "' preserveAspectRatio='xMidYMid meet'>"
+                & _HoverExtras
+                & _Guides
+                & "<polyline fill='none' stroke='" & _LineColor
+                & "' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' points='"
+                & _Points
+                & "' />"
+                & _Markers
+                & _Labels
+                & _HoverLabels
+                & "</svg>"
+        RETURN
+            IF (
+                _HasData,
+                "data:image/svg+xml;utf8," & _SVGContent,
+                BLANK ()
+            )
 
     annotation DAXLIB_PackageId = DataZoe.SVG
     annotation DAXLIB_PackageVersion = 0.1.0

--- a/packages/d/datazoe.svg/0.1.0/manifest.daxlib
+++ b/packages/d/datazoe.svg/0.1.0/manifest.daxlib
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/sql-bi/daxlib/refs/heads/main/schemas/manifest/1.0.0/manifest.1.0.0.schema.json",
+  "$schema": "https://raw.githubusercontent.com/daxlib/daxlib/refs/heads/main/schemas/manifest/1.0.0/manifest.1.0.0.schema.json",
   "id": "DataZoe.SVG",
   "version": "0.1.0",
   "authors": "DataZoe",

--- a/packages/d/datazoe.svg/0.1.0/manifest.daxlib
+++ b/packages/d/datazoe.svg/0.1.0/manifest.daxlib
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/sql-bi/daxlib/refs/heads/main/schemas/manifest/1.0.0/manifest.1.0.0.schema.json",
+  "id": "DataZoe.SVG",
+  "version": "0.1.0",
+  "authors": "DataZoe",
+  "description": "SVG-based visuals authored as DAX user-defined functions. Includes TrendSVG, a compact inline trend/sparkline chart with configurable periods, date and value formats, axis labels, line color, and optional hover-only shading and value labels.",
+  "tags": "DAX,UDF,SVG,Sparkline,Trend,Visual",
+  "releaseNotes": "Initial release. Adds TrendSVG function for inline SVG trend charts.",
+  "repositoryUrl": "https://github.com/daxlib/daxlib/tree/main/packages/d/datazoe.svg",
+  "readme": "/README.md"
+}


### PR DESCRIPTION
## New package: `DataZoe.SVG` v0.1.0

Adds a new small library under `packages/d/datazoe.svg/0.1.0/` containing SVG-based visuals authored as DAX user-defined functions.

### What's included

- `manifest.daxlib` — package metadata
- `lib/functions.tmdl` — one function, `DataZoe.SVG.TrendSVG`
- `README.md` — usage docs and example

### Function: `DataZoe.SVG.TrendSVG`

Returns a `data:image/svg+xml;utf8,...` string that renders a compact inline trend / sparkline chart. Drop it into a table or matrix column formatted as **Image URL**, or into a card visual, for at-a-glance trend context next to a KPI.

Highlights:

- **Grain-agnostic** — works with any date/period column (day, month, quarter, year); uses the N most recent distinct periods at or before the current filter context.
- **Fully parameterized** — number of periods, axis label truncation, date FORMAT string, value FORMAT string, and line color are all inputs, so one function serves many measures and formats.
- **Hover-friendly** — optional `hover` mode adds green-rising / red-falling shading under each segment plus bold value labels; leave it off for a clean minimal sparkline.
- **Self-contained SVG** — no external assets, no image hosting; renders wherever Image URL columns are supported.

### Signature

```dax
DataZoe.SVG.TrendSVG(
    valueExpression,            // measure or scalar expression to plot
    periodDateColumn,           // date/period column, e.g. 'Date'[Month]
    numberOfPeriods,            // most-recent N periods, e.g. 12
    axisLabelCharactersToShow,  // e.g. 3 → "JAN"
    dateFormatString,           // FORMAT string for axis labels, e.g. "MMM"
    valueFormatString,          // FORMAT string for value labels, e.g. "$#,0"
    lineColor,                  // hex color, e.g. "#0078D4"
    hover                       // TRUE for shading + value labels, FALSE for minimal
)